### PR TITLE
Vanilla object creation is slow in ESM too

### DIFF
--- a/cjs.cjs
+++ b/cjs.cjs
@@ -8,6 +8,11 @@ class CJSClass {
   }
 }
 
+function right(value) {
+  return { _tag: 'Right', right: value }
+}
+
 module.exports = {
-  CJSClass
+  CJSClass,
+  right
 }

--- a/esm.js
+++ b/esm.js
@@ -7,3 +7,7 @@ export class ESMClass {
     return this.foo
   }
 }
+
+export function right(value) {
+  return { _tag: 'Right', right: value }
+}

--- a/index.js
+++ b/index.js
@@ -7,9 +7,10 @@ $ npx playwright-test dist/src/index.js --runner benchmark
 
 import Benchmark from 'benchmark'
 import cjs from './cjs.cjs'
-import { ESMClass } from './esm.js'
+import { ESMClass, right as esmRight } from './esm.js'
 
 const CJSClass = cjs.CJSClass
+const cjsRight = cjs.right
 
 new Benchmark.Suite()
   .add('esm', () => {
@@ -19,6 +20,12 @@ new Benchmark.Suite()
   .add('cjs', () => {
     const obj = new CJSClass()
     obj.method()
+  })
+  .add('esm right', () => {
+    esmRight(Math.random())
+  })
+  .add('cjs right', () => {
+    cjsRight(Math.random())
   })
   .on('error', (err) => {
     console.error(err)


### PR DESCRIPTION
## Version 
v14.21.1, v16.18.1, v18.12.1

## Platform

Darwin MBP.local 22.1.0 Darwin Kernel Version 22.1.0: Sun Oct  9 20:15:09 PDT 2022; root:xnu-8792.41.9~2/RELEASE_ARM64_T6000 arm64

Added a single function `right` that returns a plain object, not even an instance of a class. The function is exported from both CJS and ESM modules. Results:

**Node 14**
```
esm x 84,463,786 ops/sec ±0.08% (96 runs sampled)
cjs x 768,587,829 ops/sec ±2.76% (94 runs sampled)
esm right x 64,626,144 ops/sec ±0.55% (95 runs sampled)
cjs right x 74,399,158 ops/sec ±0.84% (90 runs sampled)
```

**Node 16**
```
esm x 119,305,698 ops/sec ±0.07% (100 runs sampled)
cjs x 751,574,919 ops/sec ±0.08% (96 runs sampled)
esm right x 72,751,029 ops/sec ±0.11% (93 runs sampled)
cjs right x 117,571,404 ops/sec ±0.13% (95 runs sampled)
```

**Node 18**
```
esm x 111,142,265 ops/sec ±0.11% (97 runs sampled)
cjs x 297,113,562 ops/sec ±0.08% (99 runs sampled)
esm right x 74,129,284 ops/sec ±0.12% (95 runs sampled)
cjs right x 121,939,996 ops/sec ±0.09% (100 runs sampled)
```

Also managed to run the same script on `Linux ubuntu-s-1vcpu-512mb-10gb-ams3-01 5.19.0-23-generic #24-Ubuntu SMP PREEMPT_DYNAMIC Fri Oct 14 15:39:57 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux` which is the cheapest DigitalOcean box.

**Node 14**
```
esm x 133,227,146 ops/sec ±1.67% (87 runs sampled)
cjs x 572,460,967 ops/sec ±1.30% (83 runs sampled)
esm right x 41,376,425 ops/sec ±4.05% (73 runs sampled)
cjs right x 50,660,617 ops/sec ±2.77% (75 runs sampled)
```

**Node 16**
```
esm x 141,052,717 ops/sec ±1.22% (82 runs sampled)
cjs x 567,572,171 ops/sec ±1.37% (80 runs sampled)
esm right x 49,178,760 ops/sec ±3.33% (76 runs sampled)
cjs right x 63,439,565 ops/sec ±3.45% (80 runs sampled)
```

**Node 18**
```
esm x 81,658,223 ops/sec ±2.89% (78 runs sampled)
cjs x 126,203,986 ops/sec ±3.33% (72 runs sampled)
esm right x 44,750,722 ops/sec ±4.38% (72 runs sampled)
cjs right x 56,818,462 ops/sec ±3.22% (79 runs sampled)
```